### PR TITLE
Avoid lock contention for FleetStatistics::vm_ops 

### DIFF
--- a/Models/Sorting/Main.cpp
+++ b/Models/Sorting/Main.cpp
@@ -143,7 +143,7 @@ public:
 		return lp;
 	}
 		
-	void print(std::string prefix="#\n") override {
+	void show(std::string prefix="#\n") override {
 		// make this hypothesis string show all the data too
 		extern data_t mydata;
 		
@@ -156,7 +156,7 @@ public:
 			prefix = prefix+"#Test\t" + testinput + "\t" + this->call(testinput, "<err>").string() + "\n";
 		}
 		
-		Super::print(prefix); 
+		Super::show(prefix);
 	}
 	
 	

--- a/src/Inference/BeamSearch.h
+++ b/src/Inference/BeamSearch.h
@@ -11,7 +11,7 @@
 
 //#define DEBUG_BEAMSEARCH 1
 
-extern volatile sig_atomic_t CTRL_C; 
+extern std::atomic<bool> CTRL_C;
 
 /**
  * @class BeamSearch

--- a/src/VirtualMachine/VirtualMachineState.h
+++ b/src/VirtualMachine/VirtualMachineState.h
@@ -243,6 +243,7 @@ public:
 	 */	
 	 output_t run() {
 		status = vmstatus_t::GOOD;
+		uintmax_t vm_ops = 0;
 		
 		try { 
 			
@@ -253,7 +254,7 @@ public:
 					throw VMSRuntimeError();
 				}
 				
-				FleetStatistics::vm_ops++;
+				vm_ops++;
 				
 				Instruction i = program.top(); program.pop();
 //				print("Instruction", i);
@@ -271,6 +272,9 @@ public:
 			status = vmstatus_t::ERROR;
 		}
 		
+		// Add to global counter once execution is complete.
+		FleetStatistics::vm_ops += vm_ops;
+
 		// when we exit, set the status to complete if we are good
 		// otherwise, leave it where it was
 		if(status == vmstatus_t::GOOD) {


### PR DESCRIPTION
When using the parallel tempering algorithm with a hypothesis class that makes extensive use of the interpreter, I have noticed lock contention in the incrementing of `FleetStatistics::vm_ops` in `VirtualMachineState::run`. My use-case was a bit unusual in that a large fraction of time is spent in the interpreter (in order to estimate the value of policies in RL tasks, for [this paper](https://arxiv.org/abs/2402.16668)), but I was able to get a related example working by using the sorting model (in `Models/Sorting`), which I hope demonstrates the issue.

The example uses a dataset of all permutations of `0123456`:
```
ALL_PERMS=$(python3 -c 'import itertools;a=list(range(7));out=lambda x: "".join(map(str,x));print(",".join(out(x)+":"+out(a) for x in itertools.permutations(a)))')
```
Before the fix:
```
$ ./main --data=$ALL_PERMS --steps=10000 --chains=10 --threads=10 | grep 'Elapsed time' 
# Elapsed time:	8.159 seconds
```
After the fix:
```
$ ./main --data=$ALL_PERMS --steps=10000 --chains=10 --threads=10 | grep 'Elapsed time' 
# Elapsed time:	3.325 seconds 
```

Results from profiling show that, before this change, lock contention for the increment operation causes this slowdown:
![Screenshot 2024-07-08 at 3 09 23 PM](https://github.com/piantado/Fleet/assets/1276728/3933d971-f11a-48bd-ae4a-7ca9b2260c9e)

These were run on an ARM Mac, but could run them on an x86 machine if that would be helpful.